### PR TITLE
moving cv link from menu tab to Josh's profile

### DIFF
--- a/_pages/cv.md
+++ b/_pages/cv.md
@@ -3,6 +3,6 @@ layout: page
 permalink: /cv/
 title: curriculum vitae
 description:
-nav: true
+nav: false
 ---
-<iframe src="/levylab/assets/pdf/levy_cv_geisel_latest.pdf" style="width:800px; height:800px;"></iframe>
+<iframe src="/levylab/assets/pdf/levy_cv_geisel_latest.pdf"></iframe>

--- a/_pages/cv.md
+++ b/_pages/cv.md
@@ -1,8 +1,29 @@
 ---
 layout: page
 permalink: /cv/
-title: curriculum vitae
+title: CV
 description:
-nav: false
+nav: true
 ---
-<iframe src="/levylab/assets/pdf/levy_cv_geisel_latest.pdf"></iframe>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <title>Test Layout</title>
+        <style type="text/css">
+            body, html
+            {
+                margin: 0; padding: 0; height: 100%; overflow: hidden;
+            }
+
+            #content
+            {
+                position:absolute; left: 0; right: 0; bottom: 0; top: 0px;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="content">
+            <iframe width="100%" height="100%" frameborder="0" src="/levylab/assets/pdf/levy_cv_geisel_latest.pdf"></iframe>
+        </div>
+    </body>
+</html>

--- a/_people/PI_Joshua_Levy.md
+++ b/_people/PI_Joshua_Levy.md
@@ -11,8 +11,12 @@ type: "Principal Investigator"
 lab_type: "Current"
 description: Lab Director & Co-Director of EDIT Machine Learning Group
 ---
-Github: [jlevy44](https://github.com/jlevy44/)  
+[Curriculum Vitae](/levylab/assets/pdf/levy_cv_geisel_latest.pdf)
 
-Website: [Geisel Website](https://geiselmed.dartmouth.edu/epidemiology/profile/joshua-levy-phd/)    
+[Github](https://github.com/jlevy44/)  
+
+[Profile (Geisel Website)](https://geiselmed.dartmouth.edu/epidemiology/profile/joshua-levy-phd/)
+
+<br/>
 
 Dr. Levy is an Assistant Professor in both the Departments of Pathology and Laboratory Medicine (DPLM) and Dermatology, with an adjunct appointment in the Department of Epidemiology. He is one of the founders of the Emerging Diagnostic and Investigative Technologies (EDIT) program and currently serves as the Co-Head of EDIT's Machine Learning (ML) arm. His current research touches on the four following themes: 1) designing and validating artificial intelligence (AI) technologies for digital pathology which are in maximal alignment with clinical stakeholders (“by clinicians, for clinicians”), 2) investigating spatially localized omics information and envision prospective deployment, 3) leverage AI and spatial omics technologies to further elucidate cancer pathogenesis and epidemiology; and 4) developing and applying hierarchical Bayesian techniques for the honest, fair and transparent assessment of medical AI technologies to avoid bias and overstating model effectiveness. Dr. Levy completed his PhD in the program for Quantitative Biomedical Sciences, where he developed technologies to extract insights from DNA Methylation and Histopathological slides. Prior to his dissertation research, Dr. Levy obtained his Bachelor’s in Physics from UC Berkeley, CA and worked as a software developer at the Joint Genome Institute of Lawrence Berkeley National Laboratory, CA and Zymergen, CA, where he developed high throughput genomics workflows to help engineer next-generation microbes, biofuels, and biomaterials.


### PR DESCRIPTION
Removing CV link from menu to Josh's profile because it was taking too much room
<img width="1440" alt="Screen Shot 2022-03-11 at 1 30 51 AM" src="https://user-images.githubusercontent.com/71123092/157840422-6f692e3c-c371-4f9c-ad7a-da8f2803b50f.png">

